### PR TITLE
Feature/ajax base

### DIFF
--- a/lib/Ajax.php
+++ b/lib/Ajax.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class for Cron
+ * Class for Ajax
  *
  * @package ProjectName.
  */
@@ -10,25 +10,24 @@ namespace Pixels\ProjectName;
 /**
  * Ajax class
  *
- * --> Register custom ajax endpoints
- * --> Assign handlers to endpoints
+ * --> Create handler instances Ajax endpoints
  */
 class Ajax {
+
+	/**
+	 * ExampleAjax instance
+	 *
+	 * @var ExampleAjax
+	 */
+	private $example_ajax;
 
 	/**
 	 * Class constructor
 	 */
 	public function __construct() {
 
-		// Register endpoints.
-		add_action( 'wp_ajax_nopriv_example_endpoint', array( $this, 'example_handler' ) );
-		add_action( 'wp_ajax_example_endpoint', array( $this, 'example_handler' ) );
-	}
-
-	/**
-	 * Handle example_endpoint AJAX request.
-	 */
-	public function example_handler() {
-		wp_send_json( 'ok' );
-	}
+		// Initialize individual Ajax endpoints.
+		$this->example_ajax = new Ajax\ExampleAjax();
+		
+	}	
 }

--- a/lib/Ajax.php
+++ b/lib/Ajax.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Class for Cron
+ *
+ * @package ProjectName.
+ */
+
+namespace Pixels\ProjectName;
+
+/**
+ * Ajax class
+ *
+ * --> Register custom ajax endpoints
+ * --> Assign handlers to endpoints
+ */
+class Ajax {
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+
+		// Register endpoints.
+		add_action( 'wp_ajax_nopriv_example_endpoint', array( $this, 'example_handler' ) );
+		add_action( 'wp_ajax_example_endpoint', array( $this, 'example_handler' ) );
+	}
+
+	/**
+	 * Handle example_endpoint AJAX request.
+	 */
+	public function example_handler() {
+		wp_send_json( 'ok' );
+	}
+}

--- a/lib/Ajax.php
+++ b/lib/Ajax.php
@@ -28,6 +28,6 @@ class Ajax {
 
 		// Initialize individual Ajax endpoints.
 		$this->example_ajax = new Ajax\ExampleAjax();
-		
-	}	
+
+	}
 }

--- a/lib/Ajax/ExampleAjax.php
+++ b/lib/Ajax/ExampleAjax.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class for ExampleAjax
+ *
+ * @package ProjectName.
+ */
+
+namespace Pixels\ProjectName\Ajax;
+
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * ProjectName Example Ajax class
+ *
+ * @since 1.0
+ * @author Pixels
+ */
+class ExampleAjax {
+
+	/**
+	 * Ajax endpoint name.
+	 */
+	const AJAX_ENDPOINT = 'example_endpoint';
+
+	/**
+	 * Nonce name used for this endpoint.
+	 */
+	const NONCE_NAME = 'example_endpoint';
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+
+		// Register endpoints.
+		add_action( 'wp_ajax_nopriv_' . self::AJAX_ENDPOINT, array( $this, 'handle_request' ) );
+		add_action( 'wp_ajax_' . self::AJAX_ENDPOINT, array( $this, 'handle_request' ) );
+	}
+
+	/**
+	 * Handle AJAX request.
+	 */
+	public static function handle_request() {
+
+		/**
+		 * Access data with $_REQUEST array.
+		 * Verify nonce from theme
+		 * Send json reply
+		 */
+
+		$nonce = $_REQUEST['nonce'];
+
+		// Nonce verification.
+		if( wp_verify_nonce( $nonce, self::NONCE_NAME ) ):
+
+			// Business logic.
+			wp_send_json( 'ok' );
+		else:
+			// Error handling.
+			wp_send_jso( 'not ok' );
+		endif;
+	}	
+
+} //end ExampleAjax

--- a/lib/Ajax/ExampleAjax.php
+++ b/lib/Ajax/ExampleAjax.php
@@ -7,7 +7,6 @@
 
 namespace Pixels\ProjectName\Ajax;
 
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -51,17 +50,16 @@ class ExampleAjax {
 		 * Send json reply
 		 */
 
-		$nonce = $_REQUEST['nonce'];
-
 		// Nonce verification.
-		if( wp_verify_nonce( $nonce, self::NONCE_NAME ) ):
+		if ( isset( $_REQUEST['nonce'] ) &&
+			wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), self::NONCE_NAME ) ) :
 
 			// Business logic.
 			wp_send_json( 'ok' );
-		else:
+		else :
 			// Error handling.
 			wp_send_jso( 'not ok' );
 		endif;
-	}	
+	}
 
 } //end ExampleAjax

--- a/lib/Ajax/ExampleAjax.php
+++ b/lib/Ajax/ExampleAjax.php
@@ -58,7 +58,7 @@ class ExampleAjax {
 			wp_send_json( 'ok' );
 		else :
 			// Error handling.
-			wp_send_jso( 'not ok' );
+			wp_send_json( 'not ok' );
 		endif;
 	}
 

--- a/pixels-starter-plugin.php
+++ b/pixels-starter-plugin.php
@@ -48,6 +48,13 @@ final class App {
 	private $rest;
 
 	/**
+	 * Ajax instance
+	 *
+	 * @var Ajax
+	 */
+	private $ajax;
+
+	/**
 	 * Cron instance
 	 *
 	 * @var Cron
@@ -64,6 +71,7 @@ final class App {
 		// Class instances.
 		$this->model = new Model();
 		$this->rest  = new RestAPI();
+		$this->ajax  = new Ajax();
 		$this->cron  = new Cron();
 
 		// Load plugin translations.


### PR DESCRIPTION
- Add Ajax-base class for registering Ajax endpoint handlers.
- Add Ajax-namespace for classes that handle individual Ajax endpoints. Similarly to individual Cron or Rest handlers.
- Individual handlers have class constants for endpoint name & nonce name to verify action against. For example if you want to register "my_custom_endpoint", you just need to add that as value of `AJAX_ENDPOINT` constant of your handler class. Its constructor will register the endpoints using the constant.