### PR TITLE
Feature/logger

### DIFF
--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -24,10 +24,28 @@ class Logger {
 	public static function is_production() {
 		$is_production = true;
 
-		if( WP_ENV !== 'production' );
+		if ( WP_ENV !== 'production' ) :
 			$is_production = false;
 		endif;
 
 		return $is_production;
+	}
+
+	/**
+	 * Dump given content to dum.
+	 * Essentially <pre> wrapped var_dump.
+	 *
+	 * @param mixed $content to be printed.
+	 */
+	public static function dump( $content ) {
+		if ( ! self::is_production() ) : ?>
+			<pre>
+				<?php
+				// phpcs:ignore
+				var_dump( $content );
+				?>
+			</pre>
+			<?php
+		endif;
 	}
 }

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -32,6 +32,21 @@ class Logger {
 	}
 
 	/**
+	 * Log using error_log.
+	 * Leaves "PixelsLogger" entry for easier search in long file.
+	 *
+	 * @param mixed $content to be logged.
+	 */
+	public static function log( $content ) {
+		if ( ! self::is_production() ) :
+			// phpcs:ignore
+			error_log( print_r( 'PixelsLogger ' . gmdate( 'Y-m-d H:i:s' ), 1 ) );
+			// phpcs:ignore
+			error_log( var_export( $content, 1 ) );
+		endif;
+	}
+
+	/**
 	 * Dump given content to dom.
 	 * Essentially <pre> wrapped var_dump.
 	 *

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -32,7 +32,7 @@ class Logger {
 	}
 
 	/**
-	 * Dump given content to dum.
+	 * Dump given content to dom.
 	 * Essentially <pre> wrapped var_dump.
 	 *
 	 * @param mixed $content to be printed.
@@ -46,6 +46,19 @@ class Logger {
 				?>
 			</pre>
 			<?php
+		endif;
+	}
+
+	/**
+	 * Dump given content to dom & exit.
+	 *
+	 * @param mixed $content to be printed.
+	 */
+	public static function die( $content ) {
+		if ( ! self::is_production() ) :
+			// phpcs:ignore
+			var_dump( $content );
+			exit;
 		endif;
 	}
 }

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Class for Logger
+ *
+ * @package ProjectName.
+ */
+
+namespace Pixels\ProjectName;
+
+/**
+ * Logger class
+ *
+ * --> Contains shorthand logging methods
+ * --> Dump, log to file or console.log.
+ */
+class Logger {
+
+	/**
+	 * Check if production environment.
+	 * Disallow logs there.
+	 *
+	 * @return bool $is_production based on env.
+	 */
+	public static function is_production() {
+		$is_production = true;
+
+		if( WP_ENV !== 'production' );
+			$is_production = false;
+		endif;
+
+		return $is_production;
+	}
+}

--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -11,6 +11,7 @@ namespace Pixels\ProjectName;
  * Logger class
  *
  * --> Contains shorthand logging methods
+ * --> Can not be run in production.
  * --> Dump, log to file or console.log.
  */
 class Logger {
@@ -74,6 +75,21 @@ class Logger {
 			// phpcs:ignore
 			var_dump( $content );
 			exit;
+		endif;
+	}
+
+	/**
+	 * Print content using JS console.log
+	 *
+	 * @param mixed $content to be printed.
+	 */
+	public static function console( $content ) {
+		if ( ! self::is_production() ) :
+			?>
+			<script>
+				console.log( <?php echo wp_json_encode( $content ); ?> );
+			</script>
+			<?php
 		endif;
 	}
 }


### PR DESCRIPTION
Add logger class. Purpose: commonly used, rarely remembered small logging tricks for WP environment.

Log methods can only be run in non-production environment (based on .env file).

Methods:
- `dump()`: Log to DOM (vardump with pre-tags)
- `die()`:Log to DOM and die/exit
- `log()`: Log to standard log file location (eg. error_log). This one leaves behind trace "PixelsLogger [DATE & TIME] for easier search in longer log files.
- `console()`: Log to JavaScript. Prints out <script> tag with `console.log`. It's sometimes preferable to quickly see what you've got without printing to layout or file.