### PR TITLE
Fixes the generated label for post type 'name'.

### DIFF
--- a/lib/Model/PostTypes/AbstractPostType.php
+++ b/lib/Model/PostTypes/AbstractPostType.php
@@ -147,7 +147,7 @@ abstract class AbstractPostType {
 		$labels = array(
 			'name'               => sprintf(
 				_x( '%s', 'post type general name', 'pixels-starter-plugin' ),
-				$this->post_label_singular
+				$this->post_label_plural
 			),
 			'singular_name'      => sprintf( _x( '%s', 'post type singular name', 'pixels-starter-plugin' ), $this->post_label_singular ),
 			'menu_name'          => sprintf( _x( '%s', 'admin menu', 'pixels-starter-plugin' ), $this->post_label_plural ),


### PR DESCRIPTION
This label should be plural (e.g. check if you go to the 'All x' view, this is the title used at the top of the page, and should be plural (at least in English)